### PR TITLE
Type-safe casting of context[transaction]

### DIFF
--- a/extension/goext/config.go
+++ b/extension/goext/config.go
@@ -15,11 +15,7 @@
 
 package goext
 
-// ICore is an interface to core parts of Gohan: event triggering and registering
-type ICore interface {
-	TriggerEvent(event string, context Context) error
-	HandleEvent(event string, context Context) error
-
-	RegisterEventHandler(eventName string, handler func(context Context, environment IEnvironment) error, priority int)
-	RegisterSchemaEventHandler(schemaID string, eventName string, handler func(context Context, resource Resource, environment IEnvironment) error, priority int)
+// IConfig is an interface to config in Gohan
+type IConfig interface {
+	Config(key string, defaultValue interface{}) interface{}
 }

--- a/extension/goext/environment.go
+++ b/extension/goext/environment.go
@@ -21,6 +21,7 @@ import "encoding/json"
 // other packages must not be imported nor used
 type IEnvironment interface {
 	// modules
+	Config() IConfig
 	Core() ICore
 	Logger() ILogger
 	Schemas() ISchemas

--- a/extension/goext/environment.go
+++ b/extension/goext/environment.go
@@ -28,6 +28,7 @@ type IEnvironment interface {
 	Database() IDatabase
 	HTTP() IHTTP
 	Auth() IAuth
+	Util() IUtil
 
 	// state
 	Reset()

--- a/extension/goext/util.go
+++ b/extension/goext/util.go
@@ -1,5 +1,6 @@
 package goext
 
 type IUtil interface {
+	NewUUID() string
 	GetTransaction(context Context) (ITransaction, bool)
 }

--- a/extension/goext/util.go
+++ b/extension/goext/util.go
@@ -1,0 +1,5 @@
+package goext
+
+type IUtil interface {
+	GetTransaction(context Context) (ITransaction, bool)
+}

--- a/extension/goplugin/config.go
+++ b/extension/goplugin/config.go
@@ -13,13 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package goext
+package goplugin
 
-// ICore is an interface to core parts of Gohan: event triggering and registering
-type ICore interface {
-	TriggerEvent(event string, context Context) error
-	HandleEvent(event string, context Context) error
+import "github.com/cloudwan/gohan/util"
 
-	RegisterEventHandler(eventName string, handler func(context Context, environment IEnvironment) error, priority int)
-	RegisterSchemaEventHandler(schemaID string, eventName string, handler func(context Context, resource Resource, environment IEnvironment) error, priority int)
+// Config is an implementation of IConfig
+type Config struct{}
+
+// Config gets parameter from config
+func (config *Config) Config(key string, defaultValue interface{}) interface{} {
+	return util.GetConfig().GetParam(key, defaultValue)
 }

--- a/extension/goplugin/core.go
+++ b/extension/goplugin/core.go
@@ -18,8 +18,6 @@ package goplugin
 import (
 	"github.com/cloudwan/gohan/extension"
 	"github.com/cloudwan/gohan/extension/goext"
-	"github.com/cloudwan/gohan/util"
-	"github.com/twinj/uuid"
 )
 
 // Core is an implementation of ICore interface
@@ -55,17 +53,6 @@ func (core *Core) TriggerEvent(event string, context goext.Context) error {
 // HandleEvent Causes the given event to be handled within the same environment
 func (core *Core) HandleEvent(event string, context goext.Context) error {
 	return core.env.HandleEvent(event, context)
-}
-
-// NewUUID create a new unique ID
-func (core *Core) NewUUID() string {
-	return uuid.NewV4().String()
-}
-
-// Config gets parameter from config
-func (core *Core) Config(key string, defaultValue interface{}) interface{} {
-	config := util.GetConfig()
-	return config.GetParam(key, defaultValue)
 }
 
 // NewCore allocates Core

--- a/extension/goplugin/environment.go
+++ b/extension/goplugin/environment.go
@@ -79,7 +79,6 @@ type Environment struct {
 	schemasImpl  *Schemas
 	syncImpl     *Sync
 	databaseImpl *Database
-	utilImpl     *Util
 
 	name    string
 	traceID string
@@ -126,6 +125,11 @@ func (env *Environment) Types() map[string]reflect.Type {
 	return env.types
 }
 
+// Config returns an implementation to Config interface
+func (env *Environment) Config() goext.IConfig {
+	return &Config{}
+}
+
 // Core returns an implementation to Core interface
 func (env *Environment) Core() goext.ICore {
 	return env.coreImpl
@@ -162,7 +166,7 @@ func (env *Environment) Auth() goext.IAuth {
 }
 
 func (env *Environment) Util() goext.IUtil {
-	return env.utilImpl
+	return &Util{}
 }
 
 // SetDatabase sets and binds database implementation
@@ -195,10 +199,6 @@ func (env *Environment) bindDatabase(db gohan_db.DB) {
 	env.databaseImpl = NewDatabase(db)
 }
 
-func (env *Environment) bindUtil() {
-	env.utilImpl = &Util{}
-}
-
 // Start starts already loaded environment
 func (env *Environment) Start() error {
 	var err error
@@ -214,7 +214,6 @@ func (env *Environment) Start() error {
 	env.bindCore()
 	env.bindLogger()
 	env.bindSchemas()
-	env.bindUtil()
 
 	// Before start init
 	if env.beforeStartHook != nil {
@@ -701,7 +700,6 @@ func (env *Environment) Clone() extension.Environment {
 		schemasImpl:  env.schemasImpl.Clone(),
 		syncImpl:     env.syncImpl.Clone(),
 		databaseImpl: env.databaseImpl.Clone(),
-		utilImpl:     env.utilImpl.Clone(),
 
 		name: env.name,
 

--- a/extension/goplugin/environment.go
+++ b/extension/goplugin/environment.go
@@ -79,6 +79,7 @@ type Environment struct {
 	schemasImpl  *Schemas
 	syncImpl     *Sync
 	databaseImpl *Database
+	utilImpl     *Util
 
 	name    string
 	traceID string
@@ -160,6 +161,10 @@ func (env *Environment) Auth() goext.IAuth {
 	return &Auth{}
 }
 
+func (env *Environment) Util() goext.IUtil {
+	return env.utilImpl
+}
+
 // SetDatabase sets and binds database implementation
 func (env *Environment) SetDatabase(db gohan_db.DB) {
 	env.bindDatabase(db)
@@ -190,6 +195,10 @@ func (env *Environment) bindDatabase(db gohan_db.DB) {
 	env.databaseImpl = NewDatabase(db)
 }
 
+func (env *Environment) bindUtil() {
+	env.utilImpl = &Util{}
+}
+
 // Start starts already loaded environment
 func (env *Environment) Start() error {
 	var err error
@@ -205,6 +214,7 @@ func (env *Environment) Start() error {
 	env.bindCore()
 	env.bindLogger()
 	env.bindSchemas()
+	env.bindUtil()
 
 	// Before start init
 	if env.beforeStartHook != nil {
@@ -691,6 +701,7 @@ func (env *Environment) Clone() extension.Environment {
 		schemasImpl:  env.schemasImpl.Clone(),
 		syncImpl:     env.syncImpl.Clone(),
 		databaseImpl: env.databaseImpl.Clone(),
+		utilImpl:     env.utilImpl.Clone(),
 
 		name: env.name,
 

--- a/extension/goplugin/schemas.go
+++ b/extension/goplugin/schemas.go
@@ -666,19 +666,3 @@ func contextSetTransaction(ctx goext.Context, tx goext.ITransaction) goext.Conte
 	ctx["transaction"] = tx
 	return ctx
 }
-
-func contextGetTransaction(ctx goext.Context) (goext.ITransaction, bool) {
-	ctxTx := ctx["transaction"]
-	if ctxTx == nil {
-		return nil, false
-	}
-
-	switch tx := ctxTx.(type) {
-	case goext.ITransaction:
-		return tx, true
-	case transaction.Transaction:
-		return &Transaction{tx}, true
-	default:
-		panic(fmt.Sprintf("Unknown transaction type in context: %+v", ctxTx))
-	}
-}

--- a/extension/goplugin/util.go
+++ b/extension/goplugin/util.go
@@ -1,0 +1,35 @@
+package goplugin
+
+import (
+	"fmt"
+
+	"github.com/cloudwan/gohan/db/transaction"
+	"github.com/cloudwan/gohan/extension/goext"
+)
+
+type Util struct {
+}
+
+func contextGetTransaction(ctx goext.Context) (goext.ITransaction, bool) {
+	ctxTx := ctx["transaction"]
+	if ctxTx == nil {
+		return nil, false
+	}
+
+	switch tx := ctxTx.(type) {
+	case goext.ITransaction:
+		return tx, true
+	case transaction.Transaction:
+		return &Transaction{tx}, true
+	default:
+		panic(fmt.Sprintf("Unknown transaction type in context: %+v", ctxTx))
+	}
+}
+
+func (u *Util) GetTransaction(context goext.Context) (goext.ITransaction, bool) {
+	return contextGetTransaction(context)
+}
+
+func (u *Util) Clone() *Util {
+	return &Util{}
+}

--- a/extension/goplugin/util.go
+++ b/extension/goplugin/util.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/cloudwan/gohan/db/transaction"
 	"github.com/cloudwan/gohan/extension/goext"
+	"github.com/twinj/uuid"
 )
 
 type Util struct {
@@ -24,6 +25,11 @@ func contextGetTransaction(ctx goext.Context) (goext.ITransaction, bool) {
 	default:
 		panic(fmt.Sprintf("Unknown transaction type in context: %+v", ctxTx))
 	}
+}
+
+// NewUUID create a new unique ID
+func (util *Util) NewUUID() string {
+	return uuid.NewV4().String()
 }
 
 func (u *Util) GetTransaction(context goext.Context) (goext.ITransaction, bool) {


### PR DESCRIPTION
It may happen that context[Transaction] is a transactionCommitInformer, which does not fulfill goext.ITransaction.

It must be a part of public (goext) interface because Within() relies on this functionality. It may be interesting to implement Within() using dependency injection, but that complicates testing of plugins when mocks are used.